### PR TITLE
Update to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: dist/index.js


### PR DESCRIPTION
`matter_build_action` itself need to update to node24 to avoid deprecation warning
ran full CI here to test: https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/23147553069