### PR TITLE
Fix CI warnings 

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -48,7 +48,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.CLA_APP_ID }}
+          client-id: ${{ secrets.CLA_APP_ID }}
           private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
           owner: ${{ inputs.remote_org }}
           repositories: ${{ inputs.remote_repo }}

--- a/bootstrap/action.yaml
+++ b/bootstrap/action.yaml
@@ -28,7 +28,7 @@ runs:
 
     - name: Bootstrap from cache
       id: restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         key: ${{ steps.prepare.outputs.key }}
         path: |
@@ -44,7 +44,7 @@ runs:
       run: source third_party/matter_sdk/scripts/bootstrap.sh -p all,${{ inputs.platform }}
 
     - name: Save bootstrap cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: ${{ steps.restore.outputs.cache-hit != 'true' }}
       with:
         key: ${{ steps.prepare.outputs.key }}


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Cache tools were introduced using v4, which uses Node.js 20. tools that use Node.js 20 will have support cut June 2. 
Also seeing deprecation warnings for create-github-app-token tool for input app-id (now client-id) 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Update to v5 with Node.js 24, cleans up warnings in CI and will avoid any problems come June 2 cutoff 
Update input to client-id

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency and input renames with no application or security logic changes.
> 
> **Overview**
> Updates CI to clear deprecation warnings and stay on supported GitHub Actions runtimes.
> 
> The reusable **CLA** workflow now passes `client-id` instead of the deprecated `app-id` to `actions/create-github-app-token@v3`. The composite **bootstrap** action bumps `actions/cache/restore` and `actions/cache/save` from **v4** to **v5** (Node.js 24), ahead of the June 2 cutoff for Node 20–based action runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 024ecb91223f491184b974cd11c1fe6a3275b7ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->